### PR TITLE
Update Dive Computer listings to list as of 4.6 Beta 2

### DIFF
--- a/_pages/supported-dive-computers.de
+++ b/_pages/supported-dive-computers.de
@@ -15,36 +15,42 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
-<p>Dies ist die Liste der von Subsurface unterstützten Tauchcomputer (mit Hilfe von libdivecomputer). Stand October 2015.</p>
+<p>Dies ist die Liste der von Subsurface unterstützten Tauchcomputer (mit Hilfe von libdivecomputer). Stand Januar 2017.</p>
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -53,28 +59,28 @@ published: true
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>

--- a/_pages/supported-dive-computers.en
+++ b/_pages/supported-dive-computers.en
@@ -15,37 +15,43 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
-This is the list of supported dive computers (through libdivecomputer) as of October 2015.
+This is the list of supported dive computers (through libdivecomputer) as of Beta 2 of Version 4.6 (January 2017).
 
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -54,28 +60,28 @@ This is the list of supported dive computers (through libdivecomputer) as of Oct
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>
@@ -89,7 +95,9 @@ This is the list of supported dive computers (through libdivecomputer) as of Oct
     <dt>Zeagle</dt><dd><ul>
             <li>N2iTiON3</li>
         </ul>
-</dd></dl>subsurface can also read the XML files that can be exported by
+    </dd>
+</dl>
+Subsurface can also read the XML files that can be exported by
 <ul>
 	<li><a href="http://divinglog.de/">Divinglog</a></li>
 	<li><a href="http://www.jdivelog.org/">JDivelog</a></li>

--- a/_pages/supported-dive-computers.es
+++ b/_pages/supported-dive-computers.es
@@ -15,36 +15,42 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
-<p>Esta es la lista de ordenadores de buceo soportados (a través de libdivecomputer) a fecha Octubre de 2015.</p>
+<p>Esta es la lista de ordenadores de buceo soportados (a través de libdivecomputer) desde el Beta 2 de versión 4.6 (Enero 2017)</p>
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -53,28 +59,28 @@ published: true
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>

--- a/_pages/supported-dive-computers.fr
+++ b/_pages/supported-dive-computers.fr
@@ -15,36 +15,42 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
-<p>Voici la liste des modèles d'ordinateur de plongée pris en charge (via libdivecomputer) en octobre 2015.</p>
+<p>Voici la liste des modèles d'ordinateur de plongée pris en charge (via libdivecomputer) en Janvier 2017.</p>
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -53,28 +59,28 @@ published: true
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>

--- a/_pages/supported-dive-computers.it
+++ b/_pages/supported-dive-computers.it
@@ -16,36 +16,42 @@ published: true
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
 <p><br />
-Questa &egrave; la lista dei computer subacquei supportati (attraverso libdivecomputer) ad ottobre 2015.</p>
+Questa &egrave; la lista dei computer subacquei supportati (attraverso libdivecomputer) ad Gennaio 2017.</p>
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -54,28 +60,28 @@ Questa &egrave; la lista dei computer subacquei supportati (attraverso libdiveco
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>

--- a/_pages/supported-dive-computers.pl
+++ b/_pages/supported-dive-computers.pl
@@ -15,36 +15,42 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
-Lista obsługiwanych komputerów nurkowych (poprzez bibliotekę libdivecomputer) - stan na październik 2015.
+Lista obsługiwanych komputerów nurkowych (poprzez bibliotekę libdivecomputer) - stan na styczeń 2017.
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -53,28 +59,28 @@ Lista obsługiwanych komputerów nurkowych (poprzez bibliotekę libdivecomputer)
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>

--- a/_pages/supported-dive-computers.pt-pt
+++ b/_pages/supported-dive-computers.pt-pt
@@ -15,36 +15,42 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text"]
 
-<p>Esta é a lista de computadores de mergulho suportados, à data de Outubro de 2014.</p>
+<p>Esta é a lista de computadores de mergulho suportados, à data de Janeiro de 2017.</p>
 <dl><dt>Aeris</dt><dd><ul>
-            <li>A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
+            <li>500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
             <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
             <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-            <li>Voyager 2G</li></ul>
+            <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
     </dd>
     <dt>Citizen</dt><dd><ul>
             <li>Hyper Aqualand</li></ul>
     </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
+    </dd>
     <dt>Cressi</dt><dd><ul>
-            <li>Edy, Giotto, Leonardo</li></ul>
+            <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
             <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
-            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M</li></ul>
+            <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
             <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
+            <li>Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
             <li>DG03, TX1</li></ul>
@@ -53,28 +59,28 @@ published: true
             <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+            <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
             <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-            <li>Chromis, Meridian, XTender 5</li></ul>
+            <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
             <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-            <li>Petrel, Petrel 2, Predator</li></ul>
+            <li>Nerd, Petrel, Petrel 2, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-            <li>Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+            <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
             <li>XP Air, XP-10, XP-3G</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+            <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
             <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>


### PR DESCRIPTION
The new dive computers were taken from the "Download
from dive computer" menu within Subsurface. No computers
were deleted, even if they did not show on the menus. The only 
additions to most translations were the addition of January 2017 
as the date. English and Spanish had the Beta specified. 

Signed-off-by: Federico Masias fede@masias.net