### PR TITLE
4.6 release

### DIFF
--- a/_pages/about.es
+++ b/_pages/about.es
@@ -14,7 +14,7 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text" background_layout="light" text_orientation="left" use_border_color="off" border_color="#ffffff" border_style="solid"]
 
-<h2>Disponible para probar una nueva versión</h2>
+<h2>Acabamos de lanzar nuestra última versión</h2>
 Por favor, visita <a href="https://subsurface-divelog.org/es/2017/01/anuncio-subsurface-4-6/">el anuncio de Subsurface 4.6</a>.
 
 [/et_pb_text][et_pb_slider admin_label="Slider" show_arrows="on" show_pagination="on" auto="on" auto_speed="5000" auto_ignore_hover="off" parallax="off" parallax_method="off" remove_inner_shadow="off" background_position="default" background_size="default" hide_content_on_mobile="off" hide_cta_on_mobile="off" show_image_video_mobile="off" custom_button="off" button_letter_spacing="0" button_use_icon="default" button_icon_placement="right" button_on_hover="on" button_letter_spacing_hover="0" header_font_size="20"]

--- a/_pages/bugtracker.es
+++ b/_pages/bugtracker.es
@@ -15,6 +15,6 @@ published: true
 
 [/et_pb_post_title][et_pb_text admin_label="Text" background_layout="light" text_orientation="left" use_border_color="off" border_color="#ffffff" border_style="solid"]
 
-<p>Aunque estamos encantados de recibir informes acerca de fallos/bugs (¡y parches!) en nuestra <a href="http://lists.subsurface-divelog.org/cgi-bin/mailman/listinfo/subsurface">lista de distribución</a>, también tenemos un <a href="https://github.com/Subsurface-divelog/subsurface/issues">Bugtracker</a> que se puede usar para estos casos.</p>
+Aunque estamos encantados de recibir informes acerca de fallos/bugs (¡y parches!) en nuestra <a href="http://lists.subsurface-divelog.org/cgi-bin/mailman/listinfo/subsurface">lista de distribución</a>, también puedes abrir incidencias en nuestro <a href="https://github.com/Subsurface-divelog/subsurface/issues">repositorio principal en GitHub</a>.
 
 [/et_pb_text][/et_pb_column][/et_pb_row][/et_pb_section]

--- a/_pages/download.es
+++ b/_pages/download.es
@@ -20,7 +20,7 @@ published: true
 <h2>Mac</h2>
 [s-var slug="dmgurl"][s-var slug="dmg"][s-var slug="endlink"] es una imagen Mac que puede instalarse en Macs Intel de 64 bits bajo MacOs 10.7 o posterior, arrastrando Subsurface.app a tu carpeta <code>/Applications</code> .
 <h2>Linux</h2>
-El equipo de Subsurface está empezando a hacer disponibles nuestros propios binarios para varias versiones de Linux.
+El equipo de Subsurface estamos empezando a hacer disponibles nuestros propios binarios para varias versiones de Linux y también una "AppImage" genérica que debería funcionar en la mayoría de distribuciones.
 <h2>Ubuntu (14.04, 15.04, 15.10 y 16.04), LinuxMint (17), y Debian Jessie</h2>
 Para utilizar estos binarios en Ubuntu, simplemente añade el siguiente PPA a tu sistema:
 <pre><code>ppa:subsurface/subsurface</code></pre>
@@ -38,6 +38,9 @@ Ahora puedes instalar desde este repositorio.
 Asegúrate de que te estás bajando una versión actualizada con todas sus dependencias de QT5.
 <h2>OpenSUSE 13.1 / 13.2 / Tumbleweed y Fedora 22 / 23</h2>
 Para instalar el paquete oficial de Subsurface en OpenSUSE 13.1, 13.2, o Tumbleweed y también en Fedora 22, 23, dirígete a la <a href="http://software.opensuse.org/download.html?project=home:Subsurface-Divelog&amp;package=subsurface">página del servicio de compilación del proyecto</a> y sigue las instrucciones (es tan fácil como hacer dos clics).
+<h2>Resto de versiones de Linux de 64bits</h2>
+Está disponible para descargar una AppImage genérica en [s-var slug="appimageurl"][s-var slug="appimage"][s-var slug="endlink"]. Descarga este archivo y hazlo ejecutable con <code>chmod +x [s-var slug="appimage"]</code>. Luego, simplemente ejecuta el archivo. Estamos muy interesados en recibir feedback en relación a esta forma de distribuir binarios de Linux.
+
 <h2>Paquetes obsoletos mantenidos por las distribuciones</h2>
 Diversas variantes de Linux permiten instalar Subsurface desde el SO. Aunque esto es muy conveniente, recomendamos la utilización de los paquetes oficiales tal como se ha descrito con anterioridad.
 <h2>Fuentes</h2>

--- a/_posts/announcing-subsurface-4-6.es
+++ b/_posts/announcing-subsurface-4-6.es
@@ -83,4 +83,19 @@ published: true
 <li>Uwatec: Aladin 2G</li>
 </ul></dd></dl>
 
+[/et_pb_text][/et_pb_column][/et_pb_row][et_pb_row admin_label="Row"][et_pb_column type="4_4"][et_pb_text admin_label="Text" background_layout="light" text_orientation="left" use_border_color="off" border_color="#ffffff" border_style="solid"]
+
+Hay disponibles binarios para Windows, Mac y una AppImage para Linux (además de binarios específicos para varias distribuciones de Linux como Ubuntu, Debian, Linux Mint, Fedora y OpenSUSE). Se puede descargar Subsurface 4.6 desde las siguientes ubicaciones:
+<strong>Windows:</strong> <a href="https://subsurface-divelog.org/downloads/subsurface-4.6.0.exe">https://subsurface-divelog.org/downloads/subsurface-4.6.0.exe</a>
+
+<strong>Mac:</strong> <a href="https://subsurface-divelog.org/downloads/Subsurface-4.6.0.dmg">https://subsurface-divelog.org/downloads/Subsurface-4.6.0.dmg</a>
+
+<strong>Linux:</strong> Disponible para descarga una AppImage genérica en <a href="https://subsurface-divelog.org/downloads/Subsurface-4.6.0-x86_64.AppImage">Subsurface-4.6.0-x86_64.AppImage</a>. Descarga este archivo y hazlo ejecutable
+<code>chmod +x Subsurface-4.6.0-x86_64.AppImage</code> y luego simplemente ejecútalo. 
+<strong>Linux: Ubuntu: </strong>Añade <code>ppa:subsurface/subsurface</code>a tus fuentes de software; los archivos .deb del PPA también pueden instalarse en versiones suficientemente actualizadas de <strong>Debian</strong> y <strong>LinuxMint</strong>; visita la página de  <a href="https://subsurface-divelog.org/es/download/">Descargas</a> y usa <code>http://ppa.launchpad.net/subsurface/subsurface/ubuntu</code> para conseguir nuestra última versión.
+
+<strong>Linux: openSUSE / Fedora:</strong> Visita nuestro <a href="http://software.opensuse.org/download.html?project=home:Subsurface-Divelog&amp;package=subsurface">página open build service release</a>
+
+Por favor envía preguntas o problemas al <a href="https://subsurface-divelog.org/user-forum/">Foro de Usuarios</a> o registra un fallo en nuestro <a href="https://github.com/Subsurface-divelog/subsurface/issues">Bug Tracker</a>. Como nota al marge, despues de muchos problemas con nuestro viejo bugtracker, hemos cambiado a utilizar las "issues" de GitHub, por tanto, sigue el link indicado antes, no el viejo link que puedas tener guardado en tus marcadores.
+
 [/et_pb_text][/et_pb_column][/et_pb_row][/et_pb_section]


### PR DESCRIPTION
Minor changes in about.es (header) and bugtracker (github).  Mentions to appimages missed in previous version.  Last hour additions in 4.6 announcement.
TODO:  building page changes and additions (english page changing ATM)