### PR TITLE
Mention Divesoft Freedom in supported dive computers

### DIFF
--- a/_pages/supported-dive-computers.de
+++ b/_pages/supported-dive-computers.de
@@ -44,6 +44,9 @@ published: true
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.en
+++ b/_pages/supported-dive-computers.en
@@ -45,6 +45,9 @@ This is the list of supported dive computers (through libdivecomputer) as of Apr
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.es
+++ b/_pages/supported-dive-computers.es
@@ -45,6 +45,9 @@ published: true
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.it
+++ b/_pages/supported-dive-computers.it
@@ -45,6 +45,9 @@ Questa &egrave; la lista dei computer subacquei supportati (attraverso libdiveco
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.nl
+++ b/_pages/supported-dive-computers.nl
@@ -45,6 +45,9 @@ Dit is de lijst van ondersteunde duikcomputers (via libdivecomputer) per versie 
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.pl
+++ b/_pages/supported-dive-computers.pl
@@ -44,6 +44,9 @@ Lista obsługiwanych komputerów nurkowych (poprzez bibliotekę libdivecomputer)
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.pt-pt
+++ b/_pages/supported-dive-computers.pt-pt
@@ -44,6 +44,9 @@ published: true
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
     </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
+    </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>

--- a/_pages/supported-dive-computers.ru
+++ b/_pages/supported-dive-computers.ru
@@ -1,3 +1,4 @@
+# coding: utf-8
 ---
 ID: 3173
 post_title: Поддерживаемые дайв-компьютеры
@@ -44,6 +45,9 @@ published: true
     </dd>
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
+    </dd>
+    <dt>Divesoft</dt><dd><ul>
+	    <li>Freedom</li></ul>
     </dd>
     <dt>DiveSystem</dt><dd><ul>
 	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>


### PR DESCRIPTION
The freedom appears as a USB mass storage device and
we have supported importing those files for a long
time.

Signed-off-by: Robert C. Helling <helling@atdotde.de>